### PR TITLE
chore: upgrade node to v24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -118,7 +118,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Using multi stage build
-ARG BASE_IMAGE="node:22.16.0-bookworm-slim"
+ARG BASE_IMAGE="node:24.3.0-alpine3.21"
 
 #### Build stage for compiling Typescript files ####
 FROM ${BASE_IMAGE} AS builder
@@ -27,7 +27,7 @@ FROM ${BASE_IMAGE}
 ENV NODE_ENV=production
 
 # Install timezone database to allow setting timezone through TZ environment variable
-# RUN apt install tzdata
+RUN apk add --no-cache tzdata
 
 # Don’t run Node.js apps as root
 USER node

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ docker run --privileged --rm tonistiigi/binfmt --install all
 
 docker buildx build \
 --file ./Dockerfile \
---platform linux/amd64,linux/arm/v7,linux/arm64/v8 \
+--platform linux/amd64,linux/arm64/v8 \
 .
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint": "^9.30.1",
         "eslint-config-prettier": "^10.1.5",
         "husky": "^9.1.7",
-        "jest": "^30.0.3",
+        "jest": "^30.0.4",
         "lint-staged": "^16.1.2",
         "nock": "^14.0.5",
         "prettier": "^3.6.2",
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.0.2.tgz",
-      "integrity": "sha512-krGElPU0FipAqpVZ/BRZOy0MZh/ARdJ0Nj+PiH1ykFY1+VpBlYNLjdjVA5CFKxnKR6PFqFutO4Z7cdK9BlGiDA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.0.4.tgz",
+      "integrity": "sha512-tMLCDvBJBwPqMm4OAiuKm2uF5y5Qe26KgcMn+nrDSWpEW+eeFmqA0iO4zJfL16GP7gE3bUUQ3hIuUJ22AqVRnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1103,17 +1103,17 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.0.3.tgz",
-      "integrity": "sha512-Mgs1N+NSHD3Fusl7bOq1jyxv1JDAUwjy+0DhVR93Q6xcBP9/bAQ+oZhXb5TTnP5sQzAHgb7ROCKQ2SnovtxYtg==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.0.4.tgz",
+      "integrity": "sha512-MWScSO9GuU5/HoWjpXAOBs6F/iobvK1XlioelgOM9St7S0Z5WTI9kjCQLPeo4eQRRYusyLW25/J7J5lbFkrYXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.0.2",
+        "@jest/console": "30.0.4",
         "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.0.2",
-        "@jest/test-result": "30.0.2",
-        "@jest/transform": "30.0.2",
+        "@jest/reporters": "30.0.4",
+        "@jest/test-result": "30.0.4",
+        "@jest/transform": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
@@ -1122,18 +1122,18 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-changed-files": "30.0.2",
-        "jest-config": "30.0.3",
+        "jest-config": "30.0.4",
         "jest-haste-map": "30.0.2",
         "jest-message-util": "30.0.2",
         "jest-regex-util": "30.0.1",
         "jest-resolve": "30.0.2",
-        "jest-resolve-dependencies": "30.0.3",
-        "jest-runner": "30.0.3",
-        "jest-runtime": "30.0.3",
-        "jest-snapshot": "30.0.3",
+        "jest-resolve-dependencies": "30.0.4",
+        "jest-runner": "30.0.4",
+        "jest-runtime": "30.0.4",
+        "jest-snapshot": "30.0.4",
         "jest-util": "30.0.2",
         "jest-validate": "30.0.2",
-        "jest-watcher": "30.0.2",
+        "jest-watcher": "30.0.4",
         "micromatch": "^4.0.8",
         "pretty-format": "30.0.2",
         "slash": "^3.0.0"
@@ -1161,13 +1161,13 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.2.tgz",
-      "integrity": "sha512-hRLhZRJNxBiOhxIKSq2UkrlhMt3/zVFQOAi5lvS8T9I03+kxsbflwHJEF+eXEYXCrRGRhHwECT7CDk6DyngsRA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.4.tgz",
+      "integrity": "sha512-5NT+sr7ZOb8wW7C4r7wOKnRQ8zmRWQT2gW4j73IXAKp5/PX1Z8MCStBLQDYfIG3n1Sw0NRfYGdp0iIPVooBAFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.0.2",
+        "@jest/fake-timers": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "jest-mock": "30.0.2"
@@ -1177,23 +1177,23 @@
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.0.3.tgz",
-      "integrity": "sha512-73BVLqfCeWjYWPEQoYjiRZ4xuQRhQZU0WdgvbyXGRHItKQqg5e6mt2y1kVhzLSuZpmUnccZHbGynoaL7IcLU3A==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.0.4.tgz",
+      "integrity": "sha512-Z/DL7t67LBHSX4UzDyeYKqOxE/n7lbrrgEwWM3dGiH5Dgn35nk+YtgzKudmfIrBI8DRRrKYY5BCo3317HZV1Fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.0.3",
-        "jest-snapshot": "30.0.3"
+        "expect": "30.0.4",
+        "jest-snapshot": "30.0.4"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.3.tgz",
-      "integrity": "sha512-SMtBvf2sfX2agcT0dA9pXwcUrKvOSDqBY4e4iRfT+Hya33XzV35YVg+98YQFErVGA/VR1Gto5Y2+A6G9LSQ3Yg==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.4.tgz",
+      "integrity": "sha512-EgXecHDNfANeqOkcak0DxsoVI4qkDUsR7n/Lr2vtmTBjwLPBnnPOF71S11Q8IObWzxm2QgQoY6f9hzrRD3gHRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1204,9 +1204,9 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.2.tgz",
-      "integrity": "sha512-jfx0Xg7l0gmphTY9UKm5RtH12BlLYj/2Plj6wXjVW5Era4FZKfXeIvwC67WX+4q8UCFxYS20IgnMcFBcEU0DtA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.4.tgz",
+      "integrity": "sha512-qZ7nxOcL5+gwBO6LErvwVy5k06VsX/deqo2XnVUSTV0TNC9lrg8FC3dARbi+5lmrr5VyX5drragK+xLcOjvjYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1232,14 +1232,14 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.0.3.tgz",
-      "integrity": "sha512-fIduqNyYpMeeSr5iEAiMn15KxCzvrmxl7X7VwLDRGj7t5CoHtbF+7K3EvKk32mOUIJ4kIvFRlaixClMH2h/Vaw==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.0.4.tgz",
+      "integrity": "sha512-avyZuxEHF2EUhFF6NEWVdxkRRV6iXXcIES66DLhuLlU7lXhtFG/ySq/a8SRZmEJSsLkNAFX6z6mm8KWyXe9OEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.2",
-        "@jest/expect": "30.0.3",
+        "@jest/environment": "30.0.4",
+        "@jest/expect": "30.0.4",
         "@jest/types": "30.0.1",
         "jest-mock": "30.0.2"
       },
@@ -1262,16 +1262,16 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.0.2.tgz",
-      "integrity": "sha512-l4QzS/oKf57F8WtPZK+vvF4Io6ukplc6XgNFu4Hd/QxaLEO9f+8dSFzUua62Oe0HKlCUjKHpltKErAgDiMJKsA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.0.4.tgz",
+      "integrity": "sha512-6ycNmP0JSJEEys1FbIzHtjl9BP0tOZ/KN6iMeAKrdvGmUsa1qfRdlQRUDKJ4P84hJ3xHw1yTqJt4fvPNHhyE+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.0.2",
-        "@jest/test-result": "30.0.2",
-        "@jest/transform": "30.0.2",
+        "@jest/console": "30.0.4",
+        "@jest/test-result": "30.0.4",
+        "@jest/transform": "30.0.4",
         "@jest/types": "30.0.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
@@ -1365,9 +1365,9 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.0.1.tgz",
-      "integrity": "sha512-6Dpv7vdtoRiISEFwYF8/c7LIvqXD7xDXtLPNzC2xqAfBznKip0MQM+rkseKwUPUpv2PJ7KW/YsnwWXrIL2xF+A==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.0.4.tgz",
+      "integrity": "sha512-BEpX8M/Y5lG7MI3fmiO+xCnacOrVsnbqVrcDZIT8aSGkKV1w2WwvRQxSWw5SIS8ozg7+h8tSj5EO1Riqqxcdag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1396,13 +1396,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.0.2.tgz",
-      "integrity": "sha512-KKMuBKkkZYP/GfHMhI+cH2/P3+taMZS3qnqqiPC1UXZTJskkCS+YU/ILCtw5anw1+YsTulDHFpDo70mmCedW8w==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.0.4.tgz",
+      "integrity": "sha512-Mfpv8kjyKTHqsuu9YugB6z1gcdB3TSSOaKlehtVaiNlClMkEHY+5ZqCY2CrEE3ntpBMlstX/ShDAf84HKWsyIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.0.2",
+        "@jest/console": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
@@ -1412,13 +1412,13 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.0.2.tgz",
-      "integrity": "sha512-fbyU5HPka0rkalZ3MXVvq0hwZY8dx3Y6SCqR64zRmh+xXlDeFl0IdL4l9e7vp4gxEXTYHbwLFA1D+WW5CucaSw==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.0.4.tgz",
+      "integrity": "sha512-bj6ePmqi4uxAE8EHE0Slmk5uBYd9Vd/PcVt06CsBxzH4bbA8nGsI1YbXl/NH+eii4XRtyrRx+Cikub0x8H4vDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.0.2",
+        "@jest/test-result": "30.0.4",
         "graceful-fs": "^4.2.11",
         "jest-haste-map": "30.0.2",
         "slash": "^3.0.0"
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.0.2.tgz",
-      "integrity": "sha512-kJIuhLMTxRF7sc0gPzPtCDib/V9KwW3I2U25b+lYCYMVqHHSrcZopS8J8H+znx9yixuFv+Iozl8raLt/4MoxrA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.0.4.tgz",
+      "integrity": "sha512-atvy4hRph/UxdCIBp+UB2jhEA/jJiUeGZ7QPgBi9jUUKNgi3WEoMXGNG7zbbELG2+88PMabUNCDchmqgJy3ELg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2322,9 +2322,9 @@
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.9.2.tgz",
-      "integrity": "sha512-tS+lqTU3N0kkthU+rYp0spAYq15DU8ld9kXkaKg9sbQqJNF+WPMuNHZQGCgdxrUOEO0j22RKMwRVhF1HTl+X8A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.10.1.tgz",
+      "integrity": "sha512-zohDKXT1Ok0yhbVGff4YAg9HUs5ietG5GpvJBPFSApZnGe7uf2cd26DRhKZbn0Be6xHUZrSzP+RAgMmzyc71EA==",
       "cpu": [
         "arm"
       ],
@@ -2336,9 +2336,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.9.2.tgz",
-      "integrity": "sha512-MffGiZULa/KmkNjHeuuflLVqfhqLv1vZLm8lWIyeADvlElJ/GLSOkoUX+5jf4/EGtfwrNFcEaB8BRas03KT0/Q==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.10.1.tgz",
+      "integrity": "sha512-tAN6k5UrTd4nicpA7s2PbjR/jagpDzAmvXFjbpTazUe5FRsFxVcBlS1F5Lzp5jtWU6bdiqRhSvd4X8rdpCffeA==",
       "cpu": [
         "arm64"
       ],
@@ -2350,9 +2350,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.9.2.tgz",
-      "integrity": "sha512-dzJYK5rohS1sYl1DHdJ3mwfwClJj5BClQnQSyAgEfggbUwA9RlROQSSbKBLqrGfsiC/VyrDPtbO8hh56fnkbsQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.10.1.tgz",
+      "integrity": "sha512-+FCsag8WkauI4dQ50XumCXdfvDCZEpMUnvZDsKMxfOisnEklpDFXc6ThY0WqybBYZbiwR5tWcFaZmI0G6b4vrg==",
       "cpu": [
         "arm64"
       ],
@@ -2364,9 +2364,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.9.2.tgz",
-      "integrity": "sha512-gaIMWK+CWtXcg9gUyznkdV54LzQ90S3X3dn8zlh+QR5Xy7Y+Efqw4Rs4im61K1juy4YNb67vmJsCDAGOnIeffQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.10.1.tgz",
+      "integrity": "sha512-qYKGGm5wk71ONcXTMZ0+J11qQeOAPz3nw6VtqrBUUELRyXFyvK8cHhHsLBFR4GHnilc2pgY1HTB2TvdW9wO26Q==",
       "cpu": [
         "x64"
       ],
@@ -2378,9 +2378,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.9.2.tgz",
-      "integrity": "sha512-S7QpkMbVoVJb0xwHFwujnwCAEDe/596xqY603rpi/ioTn9VDgBHnCCxh+UFrr5yxuMH+dliHfjwCZJXOPJGPnw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.10.1.tgz",
+      "integrity": "sha512-hOHMAhbvIQ63gkpgeNsXcWPSyvXH7ZEyeg254hY0Lp/hX8NdW+FsUWq73g9946Pc/BrcVI/I3C1cmZ4RCX9bNw==",
       "cpu": [
         "x64"
       ],
@@ -2392,9 +2392,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.9.2.tgz",
-      "integrity": "sha512-+XPUMCuCCI80I46nCDFbGum0ZODP5NWGiwS3Pj8fOgsG5/ctz+/zzuBlq/WmGa+EjWZdue6CF0aWWNv84sE1uw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.10.1.tgz",
+      "integrity": "sha512-6ds7+zzHJgTDmpe0gmFcOTvSUhG5oZukkt+cCsSb3k4Uiz2yEQB4iCRITX2hBwSW+p8gAieAfecITjgqCkswXw==",
       "cpu": [
         "arm"
       ],
@@ -2406,9 +2406,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.9.2.tgz",
-      "integrity": "sha512-sqvUyAd1JUpwbz33Ce2tuTLJKM+ucSsYpPGl2vuFwZnEIg0CmdxiZ01MHQ3j6ExuRqEDUCy8yvkDKvjYFPb8Zg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.10.1.tgz",
+      "integrity": "sha512-P7A0G2/jW00diNJyFeq4W9/nxovD62Ay8CMP4UK9OymC7qO7rG1a8Upad68/bdfpIOn7KSp7Aj/6lEW3yyznAA==",
       "cpu": [
         "arm"
       ],
@@ -2420,9 +2420,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.9.2.tgz",
-      "integrity": "sha512-UYA0MA8ajkEDCFRQdng/FVx3F6szBvk3EPnkTTQuuO9lV1kPGuTB+V9TmbDxy5ikaEgyWKxa4CI3ySjklZ9lFA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.10.1.tgz",
+      "integrity": "sha512-Cg6xzdkrpltcTPO4At+A79zkC7gPDQIgosJmVV8M104ImB6KZi1MrNXgDYIAfkhUYjPzjNooEDFRAwwPadS7ZA==",
       "cpu": [
         "arm64"
       ],
@@ -2434,9 +2434,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.9.2.tgz",
-      "integrity": "sha512-P/CO3ODU9YJIHFqAkHbquKtFst0COxdphc8TKGL5yCX75GOiVpGqd1d15ahpqu8xXVsqP4MGFP2C3LRZnnL5MA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.10.1.tgz",
+      "integrity": "sha512-aNeg99bVkXa4lt+oZbjNRPC8ZpjJTKxijg/wILrJdzNyAymO2UC/HUK1UfDjt6T7U5p/mK24T3CYOi3/+YEQSA==",
       "cpu": [
         "arm64"
       ],
@@ -2448,9 +2448,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.9.2.tgz",
-      "integrity": "sha512-uKStFlOELBxBum2s1hODPtgJhY4NxYJE9pAeyBgNEzHgTqTiVBPjfTlPFJkfxyTjQEuxZbbJlJnMCrRgD7ubzw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.10.1.tgz",
+      "integrity": "sha512-ylz5ojeXrkPrtnzVhpCO+YegG63/aKhkoTlY8PfMfBfLaUG8v6m6iqrL7sBUKdVBgOB4kSTUPt9efQdA/Y3Z/w==",
       "cpu": [
         "ppc64"
       ],
@@ -2462,9 +2462,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.9.2.tgz",
-      "integrity": "sha512-LkbNnZlhINfY9gK30AHs26IIVEZ9PEl9qOScYdmY2o81imJYI4IMnJiW0vJVtXaDHvBvxeAgEy5CflwJFIl3tQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.10.1.tgz",
+      "integrity": "sha512-xcWyhmJfXXOxK7lvE4+rLwBq+on83svlc0AIypfe6x4sMJR+S4oD7n9OynaQShfj2SufPw2KJAotnsNb+4nN2g==",
       "cpu": [
         "riscv64"
       ],
@@ -2476,9 +2476,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.9.2.tgz",
-      "integrity": "sha512-vI+e6FzLyZHSLFNomPi+nT+qUWN4YSj8pFtQZSFTtmgFoxqB6NyjxSjAxEC1m93qn6hUXhIsh8WMp+fGgxCoRg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.10.1.tgz",
+      "integrity": "sha512-mW9JZAdOCyorgi1eLJr4gX7xS67WNG9XNPYj5P8VuttK72XNsmdw9yhOO4tDANMgiLXFiSFaiL1gEpoNtRPw/A==",
       "cpu": [
         "riscv64"
       ],
@@ -2490,9 +2490,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.9.2.tgz",
-      "integrity": "sha512-sSO4AlAYhSM2RAzBsRpahcJB1msc6uYLAtP6pesPbZtptF8OU/CbCPhSRW6cnYOGuVmEmWVW5xVboAqCnWTeHQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.10.1.tgz",
+      "integrity": "sha512-NZGKhBy6xkJ0k09cWNZz4DnhBcGlhDd3W+j7EYoNvf5TSwj2K6kbmfqTWITEgkvjsMUjm1wsrc4IJaH6VtjyHQ==",
       "cpu": [
         "s390x"
       ],
@@ -2504,9 +2504,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.9.2.tgz",
-      "integrity": "sha512-jkSkwch0uPFva20Mdu8orbQjv2A3G88NExTN2oPTI1AJ+7mZfYW3cDCTyoH6OnctBKbBVeJCEqh0U02lTkqD5w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.10.1.tgz",
+      "integrity": "sha512-VsjgckJ0gNMw7p0d8In6uPYr+s0p16yrT2rvG4v2jUpEMYkpnfnCiALa9SWshbvlGjKQ98Q2x19agm3iFk8w8Q==",
       "cpu": [
         "x64"
       ],
@@ -2518,9 +2518,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.9.2.tgz",
-      "integrity": "sha512-Uk64NoiTpQbkpl+bXsbeyOPRpUoMdcUqa+hDC1KhMW7aN1lfW8PBlBH4mJ3n3Y47dYE8qi0XTxy1mBACruYBaw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.10.1.tgz",
+      "integrity": "sha512-idMnajMeejnaFi0Mx9UTLSYFDAOTfAEP7VjXNgxKApso3Eu2Njs0p2V95nNIyFi4oQVGFmIuCkoznAXtF/Zbmw==",
       "cpu": [
         "x64"
       ],
@@ -2532,9 +2532,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.9.2.tgz",
-      "integrity": "sha512-EpBGwkcjDicjR/ybC0g8wO5adPNdVuMrNalVgYcWi+gYtC1XYNuxe3rufcO7dA76OHGeVabcO6cSkPJKVcbCXQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.10.1.tgz",
+      "integrity": "sha512-7jyhjIRNFjzlr8x5pth6Oi9hv3a7ubcVYm2GBFinkBQKcFhw4nIs5BtauSNtDW1dPIGrxF0ciynCZqzxMrYMsg==",
       "cpu": [
         "wasm32"
       ],
@@ -2549,9 +2549,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.9.2.tgz",
-      "integrity": "sha512-EdFbGn7o1SxGmN6aZw9wAkehZJetFPao0VGZ9OMBwKx6TkvDuj6cNeLimF/Psi6ts9lMOe+Dt6z19fZQ9Ye2fw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.10.1.tgz",
+      "integrity": "sha512-TY79+N+Gkoo7E99K+zmsKNeiuNJYlclZJtKqsHSls8We2iGhgxtletVsiBYie93MSTDRDMI8pkBZJlIJSZPrdA==",
       "cpu": [
         "arm64"
       ],
@@ -2563,9 +2563,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.9.2.tgz",
-      "integrity": "sha512-JY9hi1p7AG+5c/dMU8o2kWemM8I6VZxfGwn1GCtf3c5i+IKcMo2NQ8OjZ4Z3/itvY/Si3K10jOBQn7qsD/whUA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.10.1.tgz",
+      "integrity": "sha512-BAJN5PEPlEV+1m8+PCtFoKm3LQ1P57B4Z+0+efU0NzmCaGk7pUaOxuPgl+m3eufVeeNBKiPDltG0sSB9qEfCxw==",
       "cpu": [
         "ia32"
       ],
@@ -2577,9 +2577,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.9.2.tgz",
-      "integrity": "sha512-ryoo+EB19lMxAd80ln9BVf8pdOAxLb97amrQ3SFN9OCRn/5M5wvwDgAe4i8ZjhpbiHoDeP8yavcTEnpKBo7lZg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.10.1.tgz",
+      "integrity": "sha512-2v3erKKmmCyIVvvhI2nF15qEbdBpISTq44m9pyd5gfIJB1PN94oePTLWEd82XUbIbvKhv76xTSeUQSCOGesLeg==",
       "cpu": [
         "x64"
       ],
@@ -2737,13 +2737,13 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.2.tgz",
-      "integrity": "sha512-A5kqR1/EUTidM2YC2YMEUDP2+19ppgOwK0IAd9Swc3q2KqFb5f9PtRUXVeZcngu0z5mDMyZ9zH2huJZSOMLiTQ==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.4.tgz",
+      "integrity": "sha512-UjG2j7sAOqsp2Xua1mS/e+ekddkSu3wpf4nZUSvXNHuVWdaOUXQ77+uyjJLDE9i0atm5x4kds8K9yb5lRsRtcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.0.2",
+        "@jest/transform": "30.0.4",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.0",
         "babel-preset-jest": "30.0.1",
@@ -3771,15 +3771,15 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.3.tgz",
-      "integrity": "sha512-HXg6NvK35/cSYZCUKAtmlgCFyqKM4frEPbzrav5hRqb0GMz0E0lS5hfzYjSaiaE5ysnp/qI2aeZkeyeIAOeXzQ==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.4.tgz",
+      "integrity": "sha512-dDLGjnP2cKbEppxVICxI/Uf4YemmGMPNy0QytCbfafbpYk9AFQsxb8Uyrxii0RPK7FWgLGlSem+07WirwS3cFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.0.3",
+        "@jest/expect-utils": "30.0.4",
         "@jest/get-type": "30.0.1",
-        "jest-matcher-utils": "30.0.3",
+        "jest-matcher-utils": "30.0.4",
         "jest-message-util": "30.0.2",
         "jest-mock": "30.0.2",
         "jest-util": "30.0.2"
@@ -4621,16 +4621,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.0.3.tgz",
-      "integrity": "sha512-Uy8xfeE/WpT2ZLGDXQmaYNzw2v8NUKuYeKGtkS6sDxwsdQihdgYCXaKIYnph1h95DN5H35ubFDm0dfmsQnjn4Q==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.0.4.tgz",
+      "integrity": "sha512-9QE0RS4WwTj/TtTC4h/eFVmFAhGNVerSB9XpJh8sqaXlP73ILcPcZ7JWjjEtJJe2m8QyBLKKfPQuK+3F+Xij/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.0.3",
+        "@jest/core": "30.0.4",
         "@jest/types": "30.0.1",
         "import-local": "^3.2.0",
-        "jest-cli": "30.0.3"
+        "jest-cli": "30.0.4"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -4663,15 +4663,15 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.0.3.tgz",
-      "integrity": "sha512-rD9qq2V28OASJHJWDRVdhoBdRs6k3u3EmBzDYcyuMby8XCO3Ll1uq9kyqM41ZcC4fMiPulMVh3qMw0cBvDbnyg==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.0.4.tgz",
+      "integrity": "sha512-o6UNVfbXbmzjYgmVPtSQrr5xFZCtkDZGdTlptYvGFSN80RuOOlTe73djvMrs+QAuSERZWcHBNIOMH+OEqvjWuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.2",
-        "@jest/expect": "30.0.3",
-        "@jest/test-result": "30.0.2",
+        "@jest/environment": "30.0.4",
+        "@jest/expect": "30.0.4",
+        "@jest/test-result": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -4679,10 +4679,10 @@
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
         "jest-each": "30.0.2",
-        "jest-matcher-utils": "30.0.3",
+        "jest-matcher-utils": "30.0.4",
         "jest-message-util": "30.0.2",
-        "jest-runtime": "30.0.3",
-        "jest-snapshot": "30.0.3",
+        "jest-runtime": "30.0.4",
+        "jest-snapshot": "30.0.4",
         "jest-util": "30.0.2",
         "p-limit": "^3.1.0",
         "pretty-format": "30.0.2",
@@ -4695,19 +4695,19 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.0.3.tgz",
-      "integrity": "sha512-UWDSj0ayhumEAxpYRlqQLrssEi29kdQ+kddP94AuHhZknrE+mT0cR0J+zMHKFe9XPfX3dKQOc2TfWki3WhFTsA==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.0.4.tgz",
+      "integrity": "sha512-3dOrP3zqCWBkjoVG1zjYJpD9143N9GUCbwaF2pFF5brnIgRLHmKcCIw+83BvF1LxggfMWBA0gxkn6RuQVuRhIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.0.3",
-        "@jest/test-result": "30.0.2",
+        "@jest/core": "30.0.4",
+        "@jest/test-result": "30.0.4",
         "@jest/types": "30.0.1",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.0.3",
+        "jest-config": "30.0.4",
         "jest-util": "30.0.2",
         "jest-validate": "30.0.2",
         "yargs": "^17.7.2"
@@ -4728,29 +4728,29 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.0.3.tgz",
-      "integrity": "sha512-j0L4oRCtJwNyZktXIqwzEiDVQXBbQ4dqXuLD/TZdn++hXIcIfZmjHgrViEy5s/+j4HvITmAXbexVZpQ/jnr0bg==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.0.4.tgz",
+      "integrity": "sha512-3dzbO6sh34thAGEjJIW0fgT0GA0EVlkski6ZzMcbW6dzhenylXAE/Mj2MI4HonroWbkKc6wU6bLVQ8dvBSZ9lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.0.1",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.0.2",
+        "@jest/test-sequencer": "30.0.4",
         "@jest/types": "30.0.1",
-        "babel-jest": "30.0.2",
+        "babel-jest": "30.0.4",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.0.3",
+        "jest-circus": "30.0.4",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.0.2",
+        "jest-environment-node": "30.0.4",
         "jest-regex-util": "30.0.1",
         "jest-resolve": "30.0.2",
-        "jest-runner": "30.0.3",
+        "jest-runner": "30.0.4",
         "jest-util": "30.0.2",
         "jest-validate": "30.0.2",
         "micromatch": "^4.0.8",
@@ -4827,9 +4827,9 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.3.tgz",
-      "integrity": "sha512-Q1TAV0cUcBTic57SVnk/mug0/ASyAqtSIOkr7RAlxx97llRYsM74+E8N5WdGJUlwCKwgxPAkVjKh653h1+HA9A==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.4.tgz",
+      "integrity": "sha512-TSjceIf6797jyd+R64NXqicttROD+Qf98fex7CowmlSn7f8+En0da1Dglwr1AXxDtVizoxXYZBlUQwNhoOXkNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4873,14 +4873,14 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.0.2.tgz",
-      "integrity": "sha512-XsGtZ0H+a70RsxAQkKuIh0D3ZlASXdZdhpOSBq9WRPq6lhe0IoQHGW0w9ZUaPiZQ/CpkIdprvlfV1QcXcvIQLQ==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.0.4.tgz",
+      "integrity": "sha512-p+rLEzC2eThXqiNh9GHHTC0OW5Ca4ZfcURp7scPjYBcmgpR9HG6750716GuUipYf2AcThU3k20B31USuiaaIEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.2",
-        "@jest/fake-timers": "30.0.2",
+        "@jest/environment": "30.0.4",
+        "@jest/fake-timers": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "jest-mock": "30.0.2",
@@ -4931,15 +4931,15 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.3.tgz",
-      "integrity": "sha512-hMpVFGFOhYmIIRGJ0HgM9htC5qUiJ00famcc9sRFchJJiLZbbVKrAztcgE6VnXLRxA3XZ0bvNA7hQWh3oHXo/A==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.4.tgz",
+      "integrity": "sha512-ubCewJ54YzeAZ2JeHHGVoU+eDIpQFsfPQs0xURPWoNiO42LGJ+QGgfSf+hFIRplkZDkhH5MOvuxHKXRTUU3dUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.0.1",
         "chalk": "^4.1.2",
-        "jest-diff": "30.0.3",
+        "jest-diff": "30.0.4",
         "pretty-format": "30.0.2"
       },
       "engines": {
@@ -5031,30 +5031,30 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.0.3.tgz",
-      "integrity": "sha512-FlL6u7LiHbF0Oe27k7DHYMq2T2aNpPhxnNo75F7lEtu4A6sSw+TKkNNUGNcVckdFoL0RCWREJsC1HsKDwKRZzQ==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.0.4.tgz",
+      "integrity": "sha512-EQBYow19B/hKr4gUTn+l8Z+YLlP2X0IoPyp0UydOtrcPbIOYzJ8LKdFd+yrbwztPQvmlBFUwGPPEzHH1bAvFAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.0.3"
+        "jest-snapshot": "30.0.4"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.0.3.tgz",
-      "integrity": "sha512-CxYBzu9WStOBBXAKkLXGoUtNOWsiS1RRmUQb6SsdUdTcqVncOau7m8AJ4cW3Mz+YL1O9pOGPSYLyvl8HBdFmkQ==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.0.4.tgz",
+      "integrity": "sha512-mxY0vTAEsowJwvFJo5pVivbCpuu6dgdXRmt3v3MXjBxFly7/lTk3Td0PaMyGOeNQUFmSuGEsGYqhbn7PA9OekQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.0.2",
-        "@jest/environment": "30.0.2",
-        "@jest/test-result": "30.0.2",
-        "@jest/transform": "30.0.2",
+        "@jest/console": "30.0.4",
+        "@jest/environment": "30.0.4",
+        "@jest/test-result": "30.0.4",
+        "@jest/transform": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -5062,14 +5062,14 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.0.2",
+        "jest-environment-node": "30.0.4",
         "jest-haste-map": "30.0.2",
         "jest-leak-detector": "30.0.2",
         "jest-message-util": "30.0.2",
         "jest-resolve": "30.0.2",
-        "jest-runtime": "30.0.3",
+        "jest-runtime": "30.0.4",
         "jest-util": "30.0.2",
-        "jest-watcher": "30.0.2",
+        "jest-watcher": "30.0.4",
         "jest-worker": "30.0.2",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
@@ -5079,18 +5079,18 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.0.3.tgz",
-      "integrity": "sha512-Xjosq0C48G9XEQOtmgrjXJwPaUPaq3sPJwHDRaiC+5wi4ZWxO6Lx6jNkizK/0JmTulVNuxP8iYwt77LGnfg3/w==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.0.4.tgz",
+      "integrity": "sha512-tUQrZ8+IzoZYIHoPDQEB4jZoPyzBjLjq7sk0KVyd5UPRjRDOsN7o6UlvaGF8ddpGsjznl9PW+KRgWqCNO+Hn7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.2",
-        "@jest/fake-timers": "30.0.2",
-        "@jest/globals": "30.0.3",
+        "@jest/environment": "30.0.4",
+        "@jest/fake-timers": "30.0.4",
+        "@jest/globals": "30.0.4",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.0.2",
-        "@jest/transform": "30.0.2",
+        "@jest/test-result": "30.0.4",
+        "@jest/transform": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -5103,7 +5103,7 @@
         "jest-mock": "30.0.2",
         "jest-regex-util": "30.0.1",
         "jest-resolve": "30.0.2",
-        "jest-snapshot": "30.0.3",
+        "jest-snapshot": "30.0.4",
         "jest-util": "30.0.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
@@ -5160,9 +5160,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.0.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.0.3.tgz",
-      "integrity": "sha512-F05JCohd3OA1N9+5aEPXA6I0qOfZDGIx0zTq5Z4yMBg2i1p5ELfBusjYAWwTkC12c7dHcbyth4QAfQbS7cRjow==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.0.4.tgz",
+      "integrity": "sha512-S/8hmSkeUib8WRUq9pWEb5zMfsOjiYWDWzFzKnjX7eDyKKgimsu9hcmsUEg8a7dPAw8s/FacxsXquq71pDgPjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5171,17 +5171,17 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.0.3",
+        "@jest/expect-utils": "30.0.4",
         "@jest/get-type": "30.0.1",
-        "@jest/snapshot-utils": "30.0.1",
-        "@jest/transform": "30.0.2",
+        "@jest/snapshot-utils": "30.0.4",
+        "@jest/transform": "30.0.4",
         "@jest/types": "30.0.1",
         "babel-preset-current-node-syntax": "^1.1.0",
         "chalk": "^4.1.2",
-        "expect": "30.0.3",
+        "expect": "30.0.4",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.0.3",
-        "jest-matcher-utils": "30.0.3",
+        "jest-diff": "30.0.4",
+        "jest-matcher-utils": "30.0.4",
         "jest-message-util": "30.0.2",
         "jest-util": "30.0.2",
         "pretty-format": "30.0.2",
@@ -5255,13 +5255,13 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.0.2",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.0.2.tgz",
-      "integrity": "sha512-vYO5+E7jJuF+XmONr6CrbXdlYrgvZqtkn6pdkgjt/dU64UAdc0v1cAVaAeWtAfUUMScxNmnUjKPUMdCpNVASwg==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.0.4.tgz",
+      "integrity": "sha512-YESbdHDs7aQOCSSKffG8jXqOKFqw4q4YqR+wHYpR5GWEQioGvL0BfbcjvKIvPEM0XGfsfJrka7jJz3Cc3gI4VQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.0.2",
+        "@jest/test-result": "30.0.4",
         "@jest/types": "30.0.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
@@ -5967,9 +5967,9 @@
       }
     },
     "node_modules/napi-postinstall": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.5.tgz",
-      "integrity": "sha512-kmsgUvCRIJohHjbZ3V8avP0I1Pekw329MVAMDzVxsrkjgdnqiwvMX5XwR+hWV66vsAtZ+iM+fVnq8RTQawUmCQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.0.tgz",
+      "integrity": "sha512-M7NqKyhODKV1gRLdkwE7pDsZP2/SC2a2vHkOYh9MCpKMbWVfyVfUw5MaH83Fv6XMjxr5jryUp3IDDL9rlxsTeA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7259,38 +7259,38 @@
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.9.2.tgz",
-      "integrity": "sha512-VUyWiTNQD7itdiMuJy+EuLEErLj3uwX/EpHQF8EOf33Dq3Ju6VW1GXm+swk6+1h7a49uv9fKZ+dft9jU7esdLA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.10.1.tgz",
+      "integrity": "sha512-EFrL7Hw4kmhZdwWO3dwwFJo6hO3FXuQ6Bg8BK/faHZ9m1YxqBS31BNSTxklIQkxK/4LlV8zTYnPsIRLBzTzjCA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.2.4"
+        "napi-postinstall": "^0.3.0"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.9.2",
-        "@unrs/resolver-binding-android-arm64": "1.9.2",
-        "@unrs/resolver-binding-darwin-arm64": "1.9.2",
-        "@unrs/resolver-binding-darwin-x64": "1.9.2",
-        "@unrs/resolver-binding-freebsd-x64": "1.9.2",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.9.2",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.9.2",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.9.2",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.9.2",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.9.2",
-        "@unrs/resolver-binding-linux-x64-musl": "1.9.2",
-        "@unrs/resolver-binding-wasm32-wasi": "1.9.2",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.9.2",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.9.2",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.9.2"
+        "@unrs/resolver-binding-android-arm-eabi": "1.10.1",
+        "@unrs/resolver-binding-android-arm64": "1.10.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.10.1",
+        "@unrs/resolver-binding-darwin-x64": "1.10.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.10.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.10.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.10.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.10.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.10.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.10.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.10.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.10.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.10.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.10.1"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^9.30.1",
     "eslint-config-prettier": "^10.1.5",
     "husky": "^9.1.7",
-    "jest": "^30.0.3",
+    "jest": "^30.0.4",
     "lint-staged": "^16.1.2",
     "nock": "^14.0.5",
     "prettier": "^3.6.2",


### PR DESCRIPTION
REAKING! Node docker image for platform linux/arm/v7 is no longer supported from v24. This is usually used by Rpi Zero, RPi 2 and RPi 3. We support only linux/amd64 and linux/arm64/v8 from now on.